### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/luisaugusto/api/security/code-scanning/1](https://github.com/luisaugusto/api/security/code-scanning/1)

To fix the problem, we need to explicitly specify the minimal required permissions using the `permissions` key, at either the workflow root or job level. In this case, since the workflow only performs source code checkout, dependency installation, and linting, it only needs read access to repository contents. The best solution is to add `permissions: contents: read` at the workflow root, ensuring all jobs (the single `lint` job in this case) are minimally privileged.  
This requires adding the following block after the workflow name and before the `on:` or `jobs:` key:

```yaml
permissions:
  contents: read
```

No other changes or imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
